### PR TITLE
Api

### DIFF
--- a/src/net/auth_comms.c
+++ b/src/net/auth_comms.c
@@ -33,7 +33,8 @@ static void send_data(jnx_char *hostname, jnx_char *port,
   jnx_socket_destroy(&sock);
 }
 static jnx_uint8 *send_data_await_reply(jnx_char *hostname, jnx_char *port,
-    unsigned int family, jnx_uint8 *buffer, jnx_int bytes, jnx_size *receipt_bytes) {
+    unsigned int family, jnx_uint8 *buffer, 
+    jnx_int bytes, jnx_size *receipt_bytes) {
   jnx_socket *sock = jnx_socket_tcp_create(family);
   jnx_uint8 *reply;
   printf("awaiting reply from %s\n",hostname);
@@ -220,7 +221,8 @@ void auth_comms_initiator_start(auth_comms_service *ac, \
     /*                                                            */
 
     jnx_uint8 *fbuffer;
-    bytes_read = handshake_generate_finish_request(s,encoded_secret,encoded_len,&fbuffer);
+    bytes_read = handshake_generate_finish_request(s,encoded_secret,
+        encoded_len,&fbuffer);
 
     jnx_size replysizetwo;
     jnx_uint8 *replytwo = send_data_await_reply(remote_peer->host_address,"9991", 
@@ -240,7 +242,8 @@ void auth_comms_initiator_start(auth_comms_service *ac, \
 
     void *finish_object;
     printf("Checking object type 2.\n");
-    if(handshake_did_receive_receiver_request(replytwo,replysizetwo,&finish_object)){
+    if(handshake_did_receive_receiver_request(replytwo,replysizetwo,
+          &finish_object)){
       printf("Unpacked auth receiver request\n");
       AuthReceiver *ar = (AuthReceiver *)finish_object;
       if(ar->is_receiving_finish == 1 && ar->is_receiving_public_key == 0) {

--- a/src/net/auth_comms.h
+++ b/src/net/auth_comms.h
@@ -24,7 +24,8 @@ typedef struct auth_comms_service {
 
 auth_comms_service *auth_comms_create();
 
-void auth_comms_listener_start(auth_comms_service *ac,discovery_service *ds,session_service *ss);
+void auth_comms_listener_start(auth_comms_service *ac,
+    discovery_service *ds,session_service *ss);
 
 void auth_comms_destroy(auth_comms_service **ac);
 

--- a/src/net/discovery.c
+++ b/src/net/discovery.c
@@ -74,6 +74,18 @@ static void send_peer_packet(discovery_service *svc) {
   debug_packet(svc, "PEER");
 #endif
 }
+static void send_stop_packet(discovery_service *svc) {
+  void *buffer;
+  size_t len = peerton(peerstore_get_local_peer(svc->peers), &buffer);
+  jnx_uint8 *message = malloc(4 + len);
+  memcpy(message, "STOP", 4);
+  memcpy(message + 4, buffer, len);
+
+  jnx_socket_udp_send(svc->sock_send, svc->broadcast_group_address, port_to_string(svc), message, len + 4);
+#ifdef DEBUG
+  debug_packet(svc, "STOP");
+#endif
+}
 static void handle_peer(discovery_service *svc, jnx_uint8 *payload, jnx_size bytesread) {
   peer *p = ntopeer(payload, bytesread);
   peerstore_store_peer(svc->peers, p);	
@@ -346,6 +358,9 @@ int discovery_service_stop(discovery_service *svc) {
   if (svc->update_thread != NULL) {
     cancel_thread(&svc->update_thread);
   }
+  send_stop_packet(svc);
+  pthread_join(svc->listening_thread->system_thread, NULL);
+
   jnx_socket_destroy(&(svc->sock_send));
   jnx_socket_udp_listener_destroy(&svc->udp_listener);
   return 0;
@@ -368,5 +383,5 @@ time_t get_last_update_time(discovery_service *svc) {
   return last_update;
 }
 void discovery_notify_peers_of_shutdown(discovery_service *svc) {
-  JNX_LOG(NULL,"Not implemented!");
+  send_stop_packet(svc);
 }

--- a/src/net/discovery.c
+++ b/src/net/discovery.c
@@ -74,18 +74,6 @@ static void send_peer_packet(discovery_service *svc) {
   debug_packet(svc, "PEER");
 #endif
 }
-static void send_stop_packet(discovery_service *svc) {
-  void *buffer;
-  size_t len = peerton(peerstore_get_local_peer(svc->peers), &buffer);
-  jnx_uint8 *message = malloc(4 + len);
-  memcpy(message, "STOP", 4);
-  memcpy(message + 4, buffer, len);
-
-  jnx_socket_udp_send(svc->sock_send, svc->broadcast_group_address, port_to_string(svc), message, len + 4);
-#ifdef DEBUG
-  debug_packet(svc, "STOP");
-#endif
-}
 static void handle_peer(discovery_service *svc, jnx_uint8 *payload, jnx_size bytesread) {
   peer *p = ntopeer(payload, bytesread);
   peerstore_store_peer(svc->peers, p);	
@@ -358,9 +346,6 @@ int discovery_service_stop(discovery_service *svc) {
   if (svc->update_thread != NULL) {
     cancel_thread(&svc->update_thread);
   }
-  send_stop_packet(svc);
-  pthread_join(svc->listening_thread->system_thread, NULL);
-
   jnx_socket_destroy(&(svc->sock_send));
   jnx_socket_udp_listener_destroy(&svc->udp_listener);
   return 0;
@@ -383,5 +368,5 @@ time_t get_last_update_time(discovery_service *svc) {
   return last_update;
 }
 void discovery_notify_peers_of_shutdown(discovery_service *svc) {
-  send_stop_packet(svc);
+  JNX_LOG(NULL,"Not implemented!");
 }

--- a/src/net/secure_comms.h
+++ b/src/net/secure_comms.h
@@ -24,4 +24,7 @@ void secure_comms_receiver_start(discovery_service *ds,
 
 void secure_comms_initiator_start(discovery_service *ds,
     session *s,jnx_unsigned_int addr_family); 
+
+void secure_comms_end(discovery_service *ds,session *s);
+
 #endif /* !SECURE_COMMS_H */

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -36,7 +36,9 @@ session_state session_message_read_and_decrypt(session *s,
 }
 session_state session_disconnect(session *s) {
   if (s->is_connected) {
-    close(s->secure_comms_fd);
+    if(s->secure_comms_fd) {
+      close(s->secure_comms_fd);
+    }
   }
   s->is_connected = 0;
   return SESSION_STATE_OKAY;

--- a/src/session/session_service.c
+++ b/src/session/session_service.c
@@ -215,10 +215,11 @@ session_state session_service_link_sessions(session_service *s,
   int r = fn(osession,optargs); 
   return r ? SESSION_STATE_FAIL : SESSION_STATE_OKAY;
 }
-session_state session_service_unlink_sessions(session_service *s,\
-    jnx_guid *session_guid) {
+session_state session_service_unlink_sessions(session_service *s,
+    session_unlinking_service_func fn, void *optargs, jnx_guid \
+    *session_guid) {
+
   session *osession;
-  
   session_state e = session_service_fetch_session(s,session_guid,&osession);
   if(e != SESSION_STATE_OKAY) {
     return e;
@@ -230,10 +231,12 @@ session_state session_service_unlink_sessions(session_service *s,\
   osession->remote_peer_guid = h;
   JNXCHECK(is_guid_blank(&osession->local_peer_guid));
   JNXCHECK(is_guid_blank(&osession->remote_peer_guid));
-  
+ 
+  int r = fn(osession,optargs);
+
   session_disconnect(osession);
 
-  return SESSION_STATE_OKAY;
+  return r ? SESSION_STATE_FAIL : SESSION_STATE_OKAY;
 }
 jnx_int session_service_session_is_linked(session_service *s,\
     jnx_guid *session_guid) {

--- a/src/session/session_service.c
+++ b/src/session/session_service.c
@@ -202,8 +202,9 @@ session_state session_service_destroy_session(session_service *service,\
   service->session_list = cl;
   return e;
 }
-session_state session_service_link_sessions(session_service *s,\
-    jnx_guid *session_guid,peer *local_peer, peer *remote_peer) {
+session_state session_service_link_sessions(session_service *s,
+    session_linking_service_func fn,void *optargs,
+    jnx_guid *session_guid, peer *local_peer, peer *remote_peer) { 
   session *osession;
   session_state e = session_service_fetch_session(s,session_guid,&osession);
   if(e != SESSION_STATE_OKAY) {
@@ -211,7 +212,8 @@ session_state session_service_link_sessions(session_service *s,\
   }
   osession->local_peer_guid = local_peer->guid;
   osession->remote_peer_guid = remote_peer->guid;
-  return e;
+  int r = fn(osession,optargs); 
+  return r ? SESSION_STATE_FAIL : SESSION_STATE_OKAY;
 }
 session_state session_service_unlink_sessions(session_service *s,\
     jnx_guid *session_guid) {
@@ -228,6 +230,9 @@ session_state session_service_unlink_sessions(session_service *s,\
   osession->remote_peer_guid = h;
   JNXCHECK(is_guid_blank(&osession->local_peer_guid));
   JNXCHECK(is_guid_blank(&osession->remote_peer_guid));
+  
+  session_disconnect(osession);
+
   return SESSION_STATE_OKAY;
 }
 jnx_int session_service_session_is_linked(session_service *s,\

--- a/src/session/session_service.c
+++ b/src/session/session_service.c
@@ -233,9 +233,8 @@ session_state session_service_unlink_sessions(session_service *s,
   JNXCHECK(is_guid_blank(&osession->remote_peer_guid));
  
   int r = fn(osession,optargs);
-
   session_disconnect(osession);
-
+  JNX_LOG(NULL,"Disconnected session");
   return r ? SESSION_STATE_FAIL : SESSION_STATE_OKAY;
 }
 jnx_int session_service_session_is_linked(session_service *s,\

--- a/src/session/session_service.h
+++ b/src/session/session_service.h
@@ -28,6 +28,8 @@ typedef struct session_service {
   jnx_list *session_list;
 }session_service;
 
+typedef int (*session_linking_service_func)(session *s,void *optargs);
+
 session_service *session_service_create();
 
 void session_service_destroy(session_service **service);
@@ -47,8 +49,8 @@ session_state session_service_fetch_all_sessions(session_service *service,\
 session_state session_service_destroy_session(session_service *service,jnx_guid \
     *session_guid);
 
-session_state session_service_link_sessions(session_service *s,jnx_guid \
-    *session_guid, peer *local_peer, peer *remote_peer);
+session_state session_service_link_sessions(session_service *s, session_linking_service_func fn,void *optargs,\
+    jnx_guid *session_guid, peer *local_peer, peer *remote_peer);
 
 session_state session_service_unlink_sessions(session_service *s,jnx_guid \
     *session_guid);

--- a/src/session/session_service.h
+++ b/src/session/session_service.h
@@ -30,6 +30,8 @@ typedef struct session_service {
 
 typedef int (*session_linking_service_func)(session *s,void *optargs);
 
+typedef int (*session_unlinking_service_func)(session *s,void *optargs);
+
 session_service *session_service_create();
 
 void session_service_destroy(session_service **service);
@@ -49,10 +51,12 @@ session_state session_service_fetch_all_sessions(session_service *service,\
 session_state session_service_destroy_session(session_service *service,jnx_guid \
     *session_guid);
 
-session_state session_service_link_sessions(session_service *s, session_linking_service_func fn,void *optargs,\
+session_state session_service_link_sessions(session_service *s, 
+    session_linking_service_func fn,void *optargs,\
     jnx_guid *session_guid, peer *local_peer, peer *remote_peer);
 
-session_state session_service_unlink_sessions(session_service *s,jnx_guid \
+session_state session_service_unlink_sessions(session_service *s,
+    session_unlinking_service_func fn, void *optargs, jnx_guid \
     *session_guid);
 
 jnx_int session_service_session_is_linked(session_service *,jnx_guid \

--- a/test/run_tests
+++ b/test/run_tests
@@ -25,7 +25,7 @@ function test_against_file()
 {
   file=$1
   echo "Compiling $file"
-  `$COMPILER $file src/util/*.c src/data/*.c src/net/*.c src/session/*.c src/integrity/*.c src/crypto/*.c -Isrc/crypto -Isrc/data -Isrc/err -Isrc/integrity -Isrc/net -Isrc/session -Isrc/util -o ${file:0:${#file}-2} -pthread -w -rdynamic -lcrypto -lssl -ljnxc -lprotobuf-c -g`
+  `$COMPILER $file src/util/*.c src/data/*.c src/net/*.c src/session/*.c src/integrity/*.c src/crypto/*.c -Isrc/crypto -Isrc/data -Isrc/err -Isrc/integrity -Isrc/net -Isrc/session -Isrc/util -o ${file:0:${#file}-2} -pthread -w -rdynamic -lcrypto -lssl -ljnxc -lprotobuf-c -g -DDEBUG=ON`
   ./$current
   out=$?
   if [ ! $out -eq 0 ]; then

--- a/test/test_session.c
+++ b/test/test_session.c
@@ -37,6 +37,12 @@ void test_create_destroy() {
   session_service_destroy(&service);
   JNXCHECK(service == NULL);
 }
+static int linking_did_use_functor=0;
+int linking_test_procedure(session *s, void *optargs) {
+  JNX_LOG(NULL,"Session hit linking procedure functor");
+  linking_did_use_functor=1;
+  return 0;
+}
 void test_linking() {
   JNX_LOG(NULL,"test_linking");
   session_service *service = session_service_create();
@@ -51,9 +57,12 @@ void test_linking() {
  
   peer *l = peer_create(h,"N/A","Bob", 10);
   peer *n = peer_create(g,"N/A","Bob", 10);
-  
-  e = session_service_link_sessions(service,&os->session_guid,l,n);
+  e = session_service_link_sessions(service,
+      linking_test_procedure,
+      NULL,
+      &os->session_guid,l,n);
   JNXCHECK(e == SESSION_STATE_OKAY);
+  JNXCHECK(linking_did_use_functor);
   JNXCHECK(session_service_session_is_linked(service,&os->session_guid) == 1); 
   e = session_service_unlink_sessions(service,&os->session_guid);
   JNXCHECK(e == SESSION_STATE_OKAY);

--- a/test/test_session.c
+++ b/test/test_session.c
@@ -38,9 +38,17 @@ void test_create_destroy() {
   JNXCHECK(service == NULL);
 }
 static int linking_did_use_functor=0;
+static int unlinking_did_use_functor=0;
 int linking_test_procedure(session *s, void *optargs) {
   JNX_LOG(NULL,"Session hit linking procedure functor");
   linking_did_use_functor=1;
+  return 0;
+}
+int unlinking_test_procedure(session *s, void *optargs) {
+  JNX_LOG(NULL,"Session hit unlinking procedure functor");
+  const char *arg = (const char*)optargs;
+  JNXCHECK(strcmp(arg,"PASSED") == 0);
+  unlinking_did_use_functor=1;
   return 0;
 }
 void test_linking() {
@@ -64,7 +72,11 @@ void test_linking() {
   JNXCHECK(e == SESSION_STATE_OKAY);
   JNXCHECK(linking_did_use_functor);
   JNXCHECK(session_service_session_is_linked(service,&os->session_guid) == 1); 
-  e = session_service_unlink_sessions(service,&os->session_guid);
+  e = session_service_unlink_sessions(service,
+      unlinking_test_procedure,
+      "PASSED",
+      &os->session_guid);
+  JNXCHECK(unlinking_did_use_functor);
   JNXCHECK(e == SESSION_STATE_OKAY);
   int r = session_service_session_is_linked(service,&os->session_guid);
   JNXCHECK(r == 0);


### PR DESCRIPTION
- This PR primarily involves adding functors in for linking and unlinking session.
This idea occurred to me as I didn't want to hard code links into auth_comms at the session_service level.
What happens if we switch our start up shutdown process? Instead I believe it belongs in user land level.

The idea is you'd have a callback method e.g.
```
int link_session_fn(session *s, void *optargs) {
  my_custom_authentication_process *p = optargs;
 //Potentially do other setup
  return do_some_custom_work(p,s);
}
```