### PR TITLE
Names should now be unique.

### DIFF
--- a/src/data/peerstore.c
+++ b/src/data/peerstore.c
@@ -70,6 +70,8 @@ static void handle_peer_reconnection(peerstore *ps, peer *p) {
 }
 
 static void ensure_username_unique(peerstore *ps, peer *p, char *guid_str) {
+  const char **keys;
+  int numkeys = jnx_hash_get_keys(NAMESTORE(ps->namestore), &keys);
   char *current_guid = jnx_hash_get(NAMESTORE(ps->namestore), p->user_name);
   if (jnx_hash_get(NAMESTORE(ps->namestore), p->user_name) != NULL) {
     char *unique_username;

--- a/test/unit_test/test_peerstore.c
+++ b/test/unit_test/test_peerstore.c
@@ -30,7 +30,7 @@ peer *local_test_peer() {
   for (i = 0; i < 16; i++) {
     guid.guid[i] = i;
   }
-  return peer_create(guid, "127.0.0.1", "LocalUser", 10);
+  return peer_create(guid, "127.0.0.1", "Local User", 10);
 }
 peer *other_test_peer() {
   jnx_guid guid;
@@ -38,7 +38,7 @@ peer *other_test_peer() {
   for (i = 0; i < 16; i++) {
     guid.guid[i] = 15;
   }
-  return peer_create(guid, "127.0.0.2", "OtherUser", 10);
+  return peer_create(guid, "127.0.0.2", "Another", 10);
 }
 peer *bob1() {
   jnx_guid guid;
@@ -65,8 +65,8 @@ void test_peerstore_lookup_by_username() {
   peerstore_store_peer(ps, local_test_peer());
   peerstore_store_peer(ps, other_test_peer());
 
-  peer *other = peerstore_lookup_by_username(ps, "OtherUser");
-  peer *local = peerstore_lookup_by_username(ps, "LocalUser");
+  peer *other = peerstore_lookup_by_username(ps, "Another");
+  peer *local = peerstore_lookup_by_username(ps, "Local User");
   
   int status = peers_compare(other, peerstore_get_local_peer(ps));
   JNXCHECK(status == PEERS_DIFFERENT);

--- a/test/unit_test/test_peerstore.c
+++ b/test/unit_test/test_peerstore.c
@@ -40,6 +40,22 @@ peer *other_test_peer() {
   }
   return peer_create(guid, "127.0.0.2", "OtherUser", 10);
 }
+peer *bob1() {
+  jnx_guid guid;
+  int i;
+  for (i = 0; i < 16; i++) {
+    guid.guid[i] = i + 1;
+  }
+  return peer_create(guid, "127.0.0.3", "Bob", 10);
+}
+peer *bob2() {
+  jnx_guid guid;
+  int i;
+  for (i = 0; i < 16; i++) {
+    guid.guid[i] = i + 2;
+  }
+  return peer_create(guid, "127.0.0.4", "Bob", 10);
+}
 peerstore *create_test_peerstore() {
   peerstore *store = peerstore_init(local_test_peer(), 0);
   return store;
@@ -55,6 +71,20 @@ void test_peerstore_lookup_by_username() {
   int status = peers_compare(other, peerstore_get_local_peer(ps));
   JNXCHECK(status == PEERS_DIFFERENT);
   status = peers_compare(local, peerstore_get_local_peer(ps));
+  JNXCHECK(status == PEERS_EQUIVALENT);
+  peerstore_destroy(&ps);
+}
+void test_peerstore_username_clash() {
+  peerstore *ps = create_test_peerstore();
+  peer *b1 = bob1();
+  peer *b2 = bob2();
+
+  peerstore_store_peer(ps, b1);
+  peerstore_store_peer(ps, b2);
+
+  int status = peers_compare(b1, peerstore_lookup_by_username(ps, "Bob"));
+  JNXCHECK(status == PEERS_EQUIVALENT);
+  status = peers_compare(b2, peerstore_lookup_by_username(ps, "Bob-0203"));
   JNXCHECK(status == PEERS_EQUIVALENT);
   peerstore_destroy(&ps);
 }
@@ -75,7 +105,10 @@ void test_peerstore_lookup_for_inactive_username() {
 int main() {
   JNXLOG(0, "test_peerstore_lookup_by_username");
   test_peerstore_lookup_by_username();
-  
+
+  JNX_LOG(0, "test_peerstore_username_clash");
+  test_peerstore_username_clash();
+
   JNXLOG(0, "test_peerstore_lookup_for_non_existant_username");
   test_peerstore_lookup_for_non_existant_username();
   


### PR DESCRIPTION
The current version of jnxlibc that core is using actually has a bug that tripped up one of the peerstore tests.

I've fixed it in jnxlibc repo (you'll see a pull request), but there were too many commits since we last synced jnxlibc (about 15 if I remember correctly) so I didn't dare apply it to whisper-core yet.

I just fixed up the test in whisper-core by changing the usernames.